### PR TITLE
Fix label of registry

### DIFF
--- a/controllers/nsm/registry.go
+++ b/controllers/nsm/registry.go
@@ -55,7 +55,7 @@ func (r *RegistryReconciler) DeploymentForRegistry(nsm *nsmv1alpha1.NSM) *appsv1
 
 	objectMeta := newObjectMeta("nsm-registry", "nsm", map[string]string{"app": "nsm"})
 
-	registryLabel := map[string]string{"nsm-component": "nsm-registry"}
+	registryLabel := map[string]string{"app": "nsm-registry"}
 
 	volTypeDirectory := corev1.HostPathDirectory
 


### PR DESCRIPTION
The wrong label was set in the registry, so nsmgr could not use the service