### PR TITLE
REPLACE go get by go install in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
Newer versions of Go no longer compile modules and install them with
the get command. The proper way to have it working is by using go
install.

Signed-off-by: acmenezes <adcmenezes@gmail.com>