### PR TITLE
Preparations for NSM integration tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,15 +126,12 @@ deploy-spire:
 	@kubectl wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-server
 
 spire-entries:
-#	cd scripts/scripts && ./spire-config.sh && ./spire-entry.sh nsm-operator nsm
-	echo "*** No SPIRE entries created ***"
+	cd scripts/scripts && ./spire-config.sh && ./spire-entry.sh nsm-operator nsm
 
 delete-spire-entries:
-#	@for entry in $$(kubectl -n spire exec spire-server-0 -c spire-server -- /opt/spire/bin/spire-server entry show | grep 'Entry ID' | awk '{print $$4}'); do \
-#	 kubectl -n spire exec spire-server-0 -c spire-server -- /opt/spire/bin/spire-server entry delete -entryID $$entry; \
-#	done
-	echo "*** No SPIRE entries deleted ***"
-
+	@for entry in $$(kubectl -n spire exec spire-server-0 -c spire-server -- /opt/spire/bin/spire-server entry show | grep 'Entry ID' | awk '{print $$4}'); do \
+	 kubectl -n spire exec spire-server-0 -c spire-server -- /opt/spire/bin/spire-server entry delete -entryID $$entry; \
+	done
 
 delete-spire:
 	kubectl delete crd spiffeids.spiffeid.spiffe.io
@@ -160,7 +157,7 @@ deploy-nsm-operator: spire-entries nsm-namespace manifests kustomize
 ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 deploy: deploy-spire deploy-nsm-operator
 
-delete-nsm-operator: delete-spire-entries
+delete-nsm-operator:
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
 ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/Makefile
+++ b/Makefile
@@ -126,12 +126,15 @@ deploy-spire:
 	@kubectl wait -n spire --timeout=1m --for=condition=ready pod -l app=spire-server
 
 spire-entries:
-	cd scripts/scripts && ./spire-config.sh && ./spire-entry.sh nsm-operator nsm
+#	cd scripts/scripts && ./spire-config.sh && ./spire-entry.sh nsm-operator nsm
+	echo "*** No SPIRE entries created ***"
 
 delete-spire-entries:
-	@for entry in $$(kubectl -n spire exec spire-server-0 -c spire-server -- /opt/spire/bin/spire-server entry show | grep 'Entry ID' | awk '{print $$4}'); do \
-	 kubectl -n spire exec spire-server-0 -c spire-server -- /opt/spire/bin/spire-server entry delete -entryID $$entry; \
-	done
+#	@for entry in $$(kubectl -n spire exec spire-server-0 -c spire-server -- /opt/spire/bin/spire-server entry show | grep 'Entry ID' | awk '{print $$4}'); do \
+#	 kubectl -n spire exec spire-server-0 -c spire-server -- /opt/spire/bin/spire-server entry delete -entryID $$entry; \
+#	done
+	echo "*** No SPIRE entries deleted ***"
+
 
 delete-spire:
 	kubectl delete crd spiffeids.spiffeid.spiffe.io

--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,10 @@ delete-nsm-operator:
 
 ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 ## It does not contain spire-server and spire-agent deletion.
-undeploy-no-spire: delete-spire-entries delete-nsm-operator delete-nsm-namespace
+undeploy-nsm-operator: delete-spire-entries delete-nsm-operator delete-nsm-namespace
 
 ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-undeploy: undeploy-no-spire delete-spire
+undeploy: undeploy-nsm-operator delete-spire
 
 ##@ Build Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -144,12 +144,12 @@ rbac-for-registry-k8s:
 
 ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 ## It does not contain spire-server and spire-agent deployment.
-deploy-no-spire: nsm-namespace spire-entries manifests kustomize 
+deploy-no-spire: nsm-namespace spire-entries manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-deploy: nsm-namespace spire manifests kustomize 
+deploy: nsm-namespace spire manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
@@ -183,7 +183,8 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE): $(LOCALBIN)
-	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+	GOBIN=$(LOCALBIN) GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v4@latest
+##	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         control-plane: nsm-operator
+        "spiffe.io/spiffe-id": "true"
     spec:
       serviceAccountName: nsm-operator
       containers:

--- a/config/samples/application/templates/nsc.yaml
+++ b/config/samples/application/templates/nsc.yaml
@@ -13,12 +13,13 @@ spec:
     metadata:
       labels:
         app: nsc-kernel
+        "spiffe.io/spiffe-id": "true"
     spec:
-      serviceAccountName: nsm-operator    
+      serviceAccountName: nsm-operator
       containers:
         - name: nsc
           securityContext:
-            privileged: true        
+            privileged: true
           image: {{ .Values.registry }}/{{ .Values.organization }}/{{ .Values.nscImage }}:{{ .Values.tag }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           env:
@@ -38,9 +39,12 @@ spec:
               mountPath: /var/lib/networkservicemesh
               readOnly: true
           resources:
-            limits:
-              memory: 40Mi
+            requests:
               cpu: 100m
+              memory: 40Mi
+            limits:
+              memory: 80Mi
+              cpu: 200m
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/config/samples/application/templates/nse.yaml
+++ b/config/samples/application/templates/nse.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: nse-kernel
+        "spiffe.io/spiffe-id": "true"
     spec:
       serviceAccountName: nsm-operator    
       containers:
@@ -22,6 +23,8 @@ spec:
           image: {{ .Values.registry }}/{{ .Values.organization }}/{{ .Values.nseImage }}:{{ .Values.tag }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           env:
+            - name: NSM_CIDR_PREFIX
+              value: 172.16.1.100/31
             - name: SPIFFE_ENDPOINT_SOCKET
               value: unix:///run/spire/sockets/agent.sock
             - name: NSM_NAME
@@ -38,9 +41,12 @@ spec:
               mountPath: /var/lib/networkservicemesh
               readOnly: true
           resources:
-            limits:
-              memory: 40Mi
+            requests:
               cpu: 100m
+              memory: 40Mi
+            limits:
+              memory: 80Mi
+              cpu: 200m
       volumes:
         - name: spire-agent-socket
           hostPath:

--- a/scripts/scripts/spire-config.sh
+++ b/scripts/scripts/spire-config.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-kubectl -n spire exec spire-server-0 -- \
+kubectl -n spire exec spire-server-0 -c spire-server -- \
 /opt/spire/bin/spire-server entry create \
 -ttl 7200 \
 -spiffeID spiffe://example.org/ns/spire/sa/spire-agent \

--- a/scripts/scripts/spire-entry.sh
+++ b/scripts/scripts/spire-entry.sh
@@ -4,7 +4,7 @@ registerWorkload()
 {
     local serviceAccount="$1"
     local namespace="$2"
-    kubectl -n spire exec spire-server-0 -- \
+    kubectl -n spire exec spire-server-0 -c spire-server -- \
     /opt/spire/bin/spire-server entry create \
     -ttl 7200 \
     -spiffeID spiffe://example.org/ns/$namespace/sa/$serviceAccount \

--- a/scripts/spire/spire.yaml
+++ b/scripts/spire/spire.yaml
@@ -1,0 +1,576 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spire
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spire-agent
+  namespace: spire
+---
+# Required cluster role to allow spire-agent to query k8s API server
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-agent-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes", "nodes/proxy"]
+  verbs: ["get"]
+- apiGroups:
+  - security.openshift.io 
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints 
+  verbs: 
+  - use
+---
+# Binds above cluster role to spire-agent service account
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-agent-cluster-role-binding
+subjects:
+- kind: ServiceAccount
+  name: spire-agent
+  namespace: spire
+roleRef:
+  kind: ClusterRole
+  name: spire-agent-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-agent
+  namespace: spire
+data:
+  agent.conf: |
+    agent {
+      data_dir = "/run/spire"
+      log_level = "DEBUG"
+      server_address = "spire-server"
+      server_port = "8081"
+      socket_path = "/run/spire/sockets/agent.sock"
+      trust_bundle_path = "/run/spire/bundle/bundle.crt"
+      trust_domain = "example.org"
+    }
+    plugins {
+      NodeAttestor "k8s_psat" {
+        plugin_data {
+          # NOTE: Change this to your cluster name
+          cluster = "nsm-cluster"
+        }
+      }
+      KeyManager "memory" {
+        plugin_data {
+        }
+      }
+      WorkloadAttestor "k8s" {
+        plugin_data {
+          # Defaults to the secure kubelet port by default.
+          # Minikube does not have a cert in the cluster CA bundle that
+          # can authenticate the kubelet cert, so skip validation.
+          skip_kubelet_verification = true
+        }
+      }
+      WorkloadAttestor "unix" {
+          plugin_data {
+          }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: spire-agent
+  namespace: spire
+  labels:
+    app: spire-agent
+spec:
+  selector:
+    matchLabels:
+      app: spire-agent
+  template:
+    metadata:
+      namespace: spire
+      labels:
+        app: spire-agent
+    spec:
+      hostPID: true
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: spire-agent
+      initContainers:
+        - name: init
+          # This is a small image with wait-for-it, choose whatever image
+          # you prefer that waits for a service to be up. This image is built
+          # from https://github.com/lqhl/wait-for-it
+          image: gcr.io/spiffe-io/wait-for-it
+          args: ["-t", "30", "spire-server:8081"]
+        - name: init-bundle
+          # Additional init container with the same wait-for-it image to
+          # provide workaround for https://github.com/spiffe/spire/issues/3032
+          # It checks if the bundle is in place and ready to be parsed or not.
+          image: gcr.io/spiffe-io/wait-for-it
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', "t=0; until [ -f /run/spire/bundle/bundle.crt 2>&1 ] || [ $t -eq 5 ]; do t=`expr $t + 1`; sleep 1; done"]
+      containers:
+        - name: spire-agent
+          image: gcr.io/spiffe-io/spire-agent:1.2.3
+          args: ["-config", "/run/spire/config/agent.conf"]
+          volumeMounts:
+            - name: spire-config
+              mountPath: /run/spire/config
+              readOnly: true
+            - name: spire-bundle
+              mountPath: /run/spire/bundle
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: false
+            - name: spire-token
+              mountPath: /var/run/secrets/tokens
+          livenessProbe:
+            exec:
+              command:
+                - /opt/spire/bin/spire-agent
+                - healthcheck
+                - -socketPath
+                - /run/spire/sockets/agent.sock
+            failureThreshold: 2
+            initialDelaySeconds: 15
+            periodSeconds: 60
+            timeoutSeconds: 3
+          readinessProbe:
+            exec:
+              command: ["/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock", "--shallow"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: spire-config
+          configMap:
+            name: spire-agent
+        - name: spire-bundle
+          configMap:
+            name: spire-bundle
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: DirectoryOrCreate
+        - name: spire-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: spire-agent
+                  expirationSeconds: 7200
+                  audience: spire-server
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spire-server
+  namespace: spire
+---
+# ClusterRole to allow spire-server node attestor to query Token Review API
+# and to be able to push certificate bundles to a configmap
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-server-trust-role
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "list", "patch", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["patch", "get", "list"]
+- apiGroups:
+  - security.openshift.io 
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints 
+  verbs: 
+  - use  
+
+---
+# Binds above cluster role to spire-server service account
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-server-trust-role-binding
+subjects:
+- kind: ServiceAccount
+  name: spire-server
+  namespace: spire
+roleRef:
+  kind: ClusterRole
+  name: spire-server-trust-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-server
+  namespace: spire
+data:
+  server.conf: |
+    server {
+      bind_address = "0.0.0.0"
+      bind_port = "8081"
+      trust_domain = "example.org"
+      data_dir = "/run/spire/data"
+      log_level = "DEBUG"
+      #AWS requires the use of RSA.  EC cryptography is not supported
+      ca_key_type = "rsa-2048"
+      default_svid_ttl = "1h"
+      ca_subject = {
+        country = ["US"],
+        organization = ["SPIFFE"],
+        common_name = "",
+      }
+    }
+    plugins {
+      DataStore "sql" {
+        plugin_data {
+          database_type = "sqlite3"
+          connection_string = "/run/spire/data/datastore.sqlite3"
+        }
+      }
+      NodeAttestor "k8s_psat" {
+        plugin_data {
+          clusters = {
+            # NOTE: Change this to your cluster name
+            "nsm-cluster" = {
+              use_token_review_api_validation = true
+              service_account_allow_list = ["spire:spire-agent"]
+            }
+          }
+        }
+      }
+      KeyManager "disk" {
+        plugin_data {
+          keys_path = "/run/spire/data/keys.json"
+        }
+      }
+      Notifier "k8sbundle" {
+        plugin_data {
+            webhook_label = "spiffe.io/webhook"
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: spire-server
+  namespace: spire
+spec:
+  type: LoadBalancer
+  ports:
+    - name: spire-server
+      port: 8081
+      targetPort: 8081
+      protocol: TCP
+    - name: spire-federation
+      port: 8443
+      targetPort: 8443
+      protocol: TCP
+  selector:
+    app: spire-server
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: spire-server
+  namespace: spire
+  labels:
+    app: spire-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spire-server
+  serviceName: spire-server
+  template:
+    metadata:
+      namespace: spire
+      labels:
+        app: spire-server
+    spec:
+      serviceAccountName: spire-server
+      shareProcessNamespace: true
+      containers:
+        - name: spire-server
+          image: gcr.io/spiffe-io/spire-server:1.2.3
+          args:
+            - -config
+            - /run/spire/config/server.conf
+          ports:
+            - containerPort: 8081
+          volumeMounts:
+            - name: spire-config
+              mountPath: /run/spire/config
+              readOnly: true
+            - name: spire-registration-socket
+              mountPath: /tmp
+              readOnly: false
+          livenessProbe:
+            exec:
+              command:
+                - /opt/spire/bin/spire-server
+                - healthcheck
+            failureThreshold: 2
+            initialDelaySeconds: 15
+            periodSeconds: 60
+            timeoutSeconds: 3
+          readinessProbe:
+            exec:
+              command: ["/opt/spire/bin/spire-server", "healthcheck", "--shallow"]
+          # This is a workaround for https://github.com/spiffe/spire/issues/2872
+          # that prevents k8s-workload-registrar container restarts until
+          # https://github.com/spiffe/spire/pull/2921 will come with SPIRE 1.3.0.
+          lifecycle:
+            postStart:
+              exec:
+                command: ["sleep", "2"]
+        - name: k8s-workload-registrar
+          image: gcr.io/spiffe-io/k8s-workload-registrar:1.2.3
+          args:
+            - -config
+            - /run/spire/config/k8s-workload-registrar.conf
+          env:
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 9443
+              name: webhook
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /run/spire/config
+              name: k8s-workload-registrar-config
+              readOnly: true
+            - mountPath: /run/spire/sockets
+              name: spire-agent-socket
+              readOnly: true
+            - name: spire-registration-socket
+              mountPath: /tmp
+              readOnly: false
+      volumes:
+        - name: spire-config
+          configMap:
+            name: spire-server
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: DirectoryOrCreate
+        - name: k8s-workload-registrar-config
+          configMap:
+            name: k8s-workload-registrar
+        - name: spire-registration-socket
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-bundle
+  namespace: spire
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-workload-registrar-role
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints", "nodes", "pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["spiffeid.spiffe.io"]
+    resources: ["spiffeids"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["spiffeid.spiffe.io"]
+    resources: ["spiffeids/status"]
+    verbs: ["get", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-workload-registrar-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-workload-registrar-role
+subjects:
+  - kind: ServiceAccount
+    name: spire-server
+    namespace: spire
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  name: spiffeids.spiffeid.spiffe.io
+spec:
+  group: spiffeid.spiffe.io
+  names:
+    kind: SpiffeID
+    listKind: SpiffeIDList
+    plural: spiffeids
+    singular: spiffeid
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: SpiffeID is the Schema for the spiffeid API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SpiffeIDSpec defines the desired state of SpiffeID
+              properties:
+                dnsNames:
+                  items:
+                    type: string
+                  type: array
+                federatesWith:
+                  items:
+                    type: string
+                  type: array
+                parentId:
+                  type: string
+                selector:
+                  properties:
+                    arbitrary:
+                      description: Arbitrary selectors
+                      items:
+                        type: string
+                      type: array
+                    containerImage:
+                      description: Container image to match for this spiffe ID
+                      type: string
+                    containerName:
+                      description: Container name to match for this spiffe ID
+                      type: string
+                    namespace:
+                      description: Namespace to match for this spiffe ID
+                      type: string
+                    nodeName:
+                      description: Node name to match for this spiffe ID
+                      type: string
+                    podLabel:
+                      additionalProperties:
+                        type: string
+                      description: Pod label name/value to match for this spiffe ID
+                      type: object
+                    podName:
+                      description: Pod name to match for this spiffe ID
+                      type: string
+                    podUid:
+                      description: Pod UID to match for this spiffe ID
+                      type: string
+                    serviceAccount:
+                      description: ServiceAccount to match for this spiffe ID
+                      type: string
+                    cluster:
+                      description: The k8s_psat cluster name
+                      type: string
+                    agent_node_uid:
+                      description: UID of the node
+                      type: string
+                  type: object
+                spiffeId:
+                  type: string
+              required:
+                - parentId
+                - selector
+                - spiffeId
+              type: object
+            status:
+              description: SpiffeIDStatus defines the observed state of SpiffeID
+              properties:
+                entryId:
+                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                  type: string
+              type: object
+          type: object
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-workload-registrar
+  namespace: spire
+spec:
+  type: ClusterIP
+  ports:
+    - name: webhook
+      protocol: TCP
+      port: 443
+      targetPort: 9443
+  selector:
+    app: spire-server
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: k8s-workload-registrar
+  labels:
+    spiffe.io/webhook: "true"
+webhooks:
+  - name: k8s-workload-registrar.spire.svc
+    admissionReviewVersions: ["v1", "v1beta1"]
+    clientConfig:
+      service:
+        name: k8s-workload-registrar
+        namespace: spire
+        path: "/validate-spiffeid-spiffe-io-v1beta1-spiffeid"
+    rules:
+    - apiGroups: ["spiffeid.spiffe.io"]
+      apiVersions: ["v1beta1"]
+      operations: ["CREATE", "UPDATE", "DELETE"]
+      resources: ["spiffeids"]
+      scope: Namespaced
+    sideEffects: None
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-workload-registrar
+  namespace: spire
+data:
+  k8s-workload-registrar.conf: |-
+    log_level = "debug"
+    trust_domain = "example.org"
+    agent_socket_path = "/run/spire/sockets/agent.sock"
+    server_socket_path = "/tmp/spire-server/private/api.sock"
+    cluster = "nsm-cluster"
+    pod_controller = true
+    add_svc_dns_names = true
+    mode = "crd"
+    webhook_enabled = true
+    identity_template = "ns/{{.Pod.Namespace}}/pod/{{.Pod.Name}}"
+    identity_template_label = "spiffe.io/spiffe-id"


### PR DESCRIPTION
- Eliminate helm usage in the operator's Makefile for SPIRE deployment. It is done via a static YAML file.
- Container names added to the spire scripts because now it contains spire-server and k8s-workload-registrar.
- delete-spire target removes all spire related objects.
- "spiffe.io.spiffe-id" label added to the manager, NSE and NSC samples.
- Configuration of NSE and NSC samples uplifted to the networkservicemesh/deployments-k8s repository.
- Get the latest kustomize from source because of Github's rate limits with no-login in case of intensive testing.
- Cleanup and reorganization of Makefile targets:
  - Deleted unnecessary target RBAC for registry.
  - spire install and spire-entries creation decomposed.