### PR TITLE
Fixes for working properly with NSM v1.8.0

### DIFF
--- a/config/samples/nsm_v1alpha1_nsm-registry-k8s.yaml
+++ b/config/samples/nsm_v1alpha1_nsm-registry-k8s.yaml
@@ -18,4 +18,4 @@ spec:
     image: ghcr.io/networkservicemesh/cmd-registry-k8s:v1.8.0
 
   webhook:
-    image: ghcr.io/networkservicemesh/admission-webhook-k8s:v1.8.0
+    image: ghcr.io/networkservicemesh/cmd-admission-webhook-k8s:v1.8.0

--- a/config/samples/nsm_v1alpha1_nsm-registry-k8s.yaml
+++ b/config/samples/nsm_v1alpha1_nsm-registry-k8s.yaml
@@ -18,4 +18,4 @@ spec:
     image: ghcr.io/networkservicemesh/cmd-registry-k8s:v1.8.0
 
   webhook:
-    image: ghcr.io/networkservicemesh/cmd-admission-webhook-k8s:v1.8.0
+    image: ghcr.io/networkservicemesh/admission-webhook-k8s:v1.8.0

--- a/config/samples/nsm_v1alpha1_nsm.yaml
+++ b/config/samples/nsm_v1alpha1_nsm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nsm-sample
   namespace: nsm
 spec:
-  version: v1.8.0
+  version: v1.6.0
   nsmPullPolicy: IfNotPresent
   nsmLogLevel: TRACE
 
@@ -18,4 +18,4 @@ spec:
     image: ghcr.io/networkservicemesh/cmd-registry-memory:v1.8.0
 
   webhook:
-    image: ghcr.io/networkservicemesh/admission-webhook-k8s:v1.8.0
+    image: ghcr.io/networkservicemesh/cmd-admission-webhook-k8s:v1.8.0

--- a/config/samples/nsm_v1alpha1_nsm.yaml
+++ b/config/samples/nsm_v1alpha1_nsm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nsm-sample
   namespace: nsm
 spec:
-  version: v1.6.0
+  version: v1.8.0
   nsmPullPolicy: IfNotPresent
   nsmLogLevel: TRACE
 
@@ -18,4 +18,4 @@ spec:
     image: ghcr.io/networkservicemesh/cmd-registry-memory:v1.8.0
 
   webhook:
-    image: ghcr.io/networkservicemesh/cmd-admission-webhook-k8s:v1.8.0
+    image: ghcr.io/networkservicemesh/admission-webhook-k8s:v1.8.0

--- a/config/samples/nsm_v1alpha1_nsm.yaml
+++ b/config/samples/nsm_v1alpha1_nsm.yaml
@@ -18,4 +18,4 @@ spec:
     image: ghcr.io/networkservicemesh/cmd-registry-memory:v1.8.0
 
   webhook:
-    image: ghcr.io/networkservicemesh/admission-webhook-k8s:v1.8.0
+    image: ghcr.io/networkservicemesh/cmd-admission-webhook-k8s:v1.8.0

--- a/controllers/nsm/admission-webhook.go
+++ b/controllers/nsm/admission-webhook.go
@@ -57,8 +57,10 @@ func (r *WebhookReconciler) DeploymentForWebhook(nsm *nsmv1alpha1.NSM) *appsv1.D
 	objectMeta := newObjectMeta("admission-webhook-k8s", "nsm", map[string]string{"app": "nsm"})
 	webhookLabel := map[string]string{"app": "admission-webhook-k8s"}
 
-	envVars := nsm.Spec.Webhook.EnvVars
-	if envVars == nil {
+	envVars := []corev1.EnvVar{}
+	if nsm.Spec.Webhook.EnvVars != nil {
+		envVars = nsm.Spec.Nsmgr.EnvVars
+	} else {
 		envVars = []corev1.EnvVar{
 			{Name: "SPIFFE_ENDPOINT_SOCKET", Value: "unix:///run/spire/sockets/agent.sock"},
 			{Name: "NSM_SERVICE_NAME", Value: "admission-webhook-svc"},

--- a/controllers/nsm/admission-webhook.go
+++ b/controllers/nsm/admission-webhook.go
@@ -57,10 +57,8 @@ func (r *WebhookReconciler) DeploymentForWebhook(nsm *nsmv1alpha1.NSM) *appsv1.D
 	objectMeta := newObjectMeta("admission-webhook-k8s", "nsm", map[string]string{"app": "nsm"})
 	webhookLabel := map[string]string{"app": "admission-webhook-k8s"}
 
-	envVars := []corev1.EnvVar{}
-	if nsm.Spec.Webhook.EnvVars != nil {
-		envVars = nsm.Spec.Nsmgr.EnvVars
-	} else {
+	envVars := nsm.Spec.Webhook.EnvVars
+	if envVars == nil {
 		envVars = []corev1.EnvVar{
 			{Name: "SPIFFE_ENDPOINT_SOCKET", Value: "unix:///run/spire/sockets/agent.sock"},
 			{Name: "NSM_SERVICE_NAME", Value: "admission-webhook-svc"},

--- a/controllers/nsm/controller.go
+++ b/controllers/nsm/controller.go
@@ -109,7 +109,7 @@ func (r *NSMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	// Add admission-webhook-k8s reconciler on demand
-	if nsm.Spec.Webhook.Image == "" {
+	if nsm.Spec.Webhook.Image != "" {
 		reconcilers = append(reconcilers,
 			NewWebhookReconciler(r.Client, Log, r.Scheme),
 			NewWebhookServiceReconciler(r.Client, Log, r.Scheme))

--- a/controllers/nsm/controller.go
+++ b/controllers/nsm/controller.go
@@ -109,7 +109,7 @@ func (r *NSMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	// Add admission-webhook-k8s reconciler on demand
-	if nsm.Spec.Webhook.Image != "" {
+	if nsm.Spec.Webhook.Image == "" {
 		reconcilers = append(reconcilers,
 			NewWebhookReconciler(r.Client, Log, r.Scheme),
 			NewWebhookServiceReconciler(r.Client, Log, r.Scheme))

--- a/controllers/nsm/forwarder.go
+++ b/controllers/nsm/forwarder.go
@@ -68,10 +68,8 @@ func (r *ForwarderReconciler) daemonSetForForwarder(nsm *nsmv1alpha1.NSM, object
 	privmode := true
 	forwarderLabel := map[string]string{"app": "forwarder", "spiffe.io/spiffe-id": "true"}
 
-	EnvVars := []corev1.EnvVar{}
-	if envVars != nil {
-		EnvVars = envVars
-	} else {
+	EnvVars := envVars
+	if EnvVars == nil {
 		EnvVars = getEnvVars(nsm, ForwarderType)
 	}
 

--- a/controllers/nsm/forwarder.go
+++ b/controllers/nsm/forwarder.go
@@ -68,8 +68,10 @@ func (r *ForwarderReconciler) daemonSetForForwarder(nsm *nsmv1alpha1.NSM, object
 	privmode := true
 	forwarderLabel := map[string]string{"app": "forwarder", "spiffe.io/spiffe-id": "true"}
 
-	EnvVars := envVars
-	if EnvVars == nil {
+	EnvVars := []corev1.EnvVar{}
+	if envVars != nil {
+		EnvVars = envVars
+	} else {
 		EnvVars = getEnvVars(nsm, ForwarderType)
 	}
 

--- a/controllers/nsm/nsmgr.go
+++ b/controllers/nsm/nsmgr.go
@@ -61,14 +61,12 @@ func (r *NsmgrReconciler) daemonSetForNSMGR(nsm *nsmv1alpha1.NSM) *appsv1.Daemon
 
 	nsmgrLabel := map[string]string{"app": "nsmgr", "spiffe.io/spiffe-id": "true"}
 
-	exclPrefEnvVars := []corev1.EnvVar{}
+	exclPrefEnvVars := nsm.Spec.ExclPref.EnvVars
 
-	if nsm.Spec.ExclPref.EnvVars == nil {
+	if exclPrefEnvVars == nil {
 		exclPrefEnvVars = []corev1.EnvVar{
 			{Name: "NSM_LOG_LEVEL", Value: getNsmLogLevel(nsm)},
 		}
-	} else {
-		exclPrefEnvVars = nsm.Spec.ExclPref.EnvVars
 	}
 
 	daemonset := &appsv1.DaemonSet{

--- a/controllers/nsm/nsmgr.go
+++ b/controllers/nsm/nsmgr.go
@@ -61,12 +61,14 @@ func (r *NsmgrReconciler) daemonSetForNSMGR(nsm *nsmv1alpha1.NSM) *appsv1.Daemon
 
 	nsmgrLabel := map[string]string{"app": "nsmgr", "spiffe.io/spiffe-id": "true"}
 
-	exclPrefEnvVars := nsm.Spec.ExclPref.EnvVars
+	exclPrefEnvVars := []corev1.EnvVar{}
 
-	if exclPrefEnvVars == nil {
+	if nsm.Spec.ExclPref.EnvVars == nil {
 		exclPrefEnvVars = []corev1.EnvVar{
 			{Name: "NSM_LOG_LEVEL", Value: getNsmLogLevel(nsm)},
 		}
+	} else {
+		exclPrefEnvVars = nsm.Spec.ExclPref.EnvVars
 	}
 
 	daemonset := &appsv1.DaemonSet{

--- a/controllers/nsm/registry.go
+++ b/controllers/nsm/registry.go
@@ -53,14 +53,10 @@ func (r *RegistryReconciler) Reconcile(ctx context.Context, nsm *nsmv1alpha1.NSM
 
 func (r *RegistryReconciler) DeploymentForRegistry(nsm *nsmv1alpha1.NSM) *appsv1.Deployment {
 
-	privmode := true
-
 	objectMeta := newObjectMeta("nsm-registry", "nsm", map[string]string{"app": "nsm"})
 
 	registryLabel := map[string]string{"app": "nsm-registry", "spiffe.io/spiffe-id": "true"}
 	volTypeDirectory := corev1.HostPathDirectory
-
-	envVar := getEnvVar(nsm)
 
 	deploy := &appsv1.Deployment{
 		ObjectMeta: objectMeta,
@@ -78,10 +74,7 @@ func (r *RegistryReconciler) DeploymentForRegistry(nsm *nsmv1alpha1.NSM) *appsv1
 						Name:            "nsm-registry",
 						Image:           nsm.Spec.Registry.Image,
 						ImagePullPolicy: nsm.Spec.NsmPullPolicy,
-						SecurityContext: &corev1.SecurityContext{
-							Privileged: &privmode,
-						},
-						Env: *envVar,
+						Env:             *getEnvVar(nsm),
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 5002,
 							HostPort:      5002}},
@@ -117,33 +110,28 @@ func (r *RegistryReconciler) DeploymentForRegistry(nsm *nsmv1alpha1.NSM) *appsv1
 }
 
 func getEnvVar(nsm *nsmv1alpha1.NSM) *[]corev1.EnvVar {
-
 	if nsm.Spec.Registry.EnvVars != nil {
 		return &nsm.Spec.Registry.EnvVars
 	}
-
-	switch nsm.Spec.Registry.Type {
-
-	case "memory":
-		return &[]corev1.EnvVar{
-			{Name: "SPIFFE_ENDPOINT_SOCKET", Value: "unix:///run/spire/sockets/agent.sock"},
-			{Name: "REGISTRY_MEMORY_LISTEN_ON", Value: "tcp://:5002"},
-			{Name: "REGISTRY_MEMORY_PROXY_REGISTRY_URL", Value: "nsmgr-proxy:5004"},
-			{Name: "REGISTRY_MEMORY_LOG_LEVEL", Value: getNsmLogLevel(nsm)},
-		}
-	case "k8s":
-		return &[]corev1.EnvVar{
-			{Name: "SPIFFE_ENDPOINT_SOCKET", Value: "unix:///run/spire/sockets/agent.sock"},
-			{Name: "REGISTRY_K8S_LISTEN_ON", Value: "tcp://:5002"},
-			{Name: "REGISTRY_K8S_PROXY_REGISTRY_URL", Value: "nsmgr-proxy:5004"},
-			{Name: "REGISTRY_K8S_LOG_LEVEL", Value: getNsmLogLevel(nsm)},
-			{Name: "REGISTRY_K8S_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.namespace",
-				},
-			}},
+	// From version 1.7.0 the names of the environment variable changed to NSM, instead of REGISTRY_K8S or REGISTRY_MEMORY
+	prefix := "NSM_"
+	if nsm.Spec.Version < "v1.7.0" {
+		switch nsm.Spec.Registry.Type {
+		case "memory":
+			prefix = "REGISTRY_MEMORY_"
+		case "k8s":
+			prefix = "REGISTRY_K8S_"
 		}
 	}
 
-	return nil
+	return &[]corev1.EnvVar{{Name: "SPIFFE_ENDPOINT_SOCKET", Value: "unix:///run/spire/sockets/agent.sock"},
+		{Name: prefix + "LISTEN_ON", Value: "tcp://:5002"},
+		{Name: prefix + "PROXY_REGISTRY_URL", Value: "nsmgr-proxy:5004"},
+		{Name: prefix + "LOG_LEVEL", Value: getNsmLogLevel(nsm)},
+		{Name: prefix + "NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.namespace",
+			},
+		}},
+	}
 }


### PR DESCRIPTION
- Corrected image name for admission-webhook-k8s in the examples.
- Some code restructuring to suppress static checker's warnings.
- Reconciling admission-webhook-k8s if image is defined in CR.
- Privileged mode (Security Context) removed from registry's manifest.
- Adopted to handle the name changes of the registry's environment variables (NSM v1.7.0).