### PR TITLE
Environment variable handling and CRD updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ IMAGE_TAG_BASE ?= quay.io/acmenezes/nsm-operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/acmenezes/nsm-operator:v1.8.0
+IMG ?= quay.io/acmenezes/nsm-operator:v1.9.0
 BUILDER ?= podman
 
 
@@ -250,10 +250,12 @@ ci-yaml:
 	cat config/rbac/role_scc.yaml >> hack/nsm-operator-ci.yaml
 	echo "" >> hack/nsm-operator-ci.yaml	
 	cat config/rbac/role-registry-k8s.yaml >> hack/nsm-operator-ci.yaml
-	echo "" >> hack/nsm-operator-ci.yaml	
+	cat config/rbac/role_admission-webhook-k8s.yaml >> hack/nsm-operator-ci.yaml
+	echo "---" >> hack/nsm-operator-ci.yaml	
 	cat config/rbac/role_binding.yaml >> hack/nsm-operator-ci.yaml
 	echo "" >> hack/nsm-operator-ci.yaml	
 	cat config/rbac/role_binding-registry-k8s.yaml >> hack/nsm-operator-ci.yaml
+	cat config/rbac/role_binding-admission-webhook-k8s.yaml >> hack/nsm-operator-ci.yaml
 	echo "---" >> hack/nsm-operator-ci.yaml
 	cat config/rbac/leader_election_role_binding.yaml >> hack/nsm-operator-ci.yaml
 	echo "---" >> hack/nsm-operator-ci.yaml

--- a/apis/nsm/v1alpha1/nsm_types.go
+++ b/apis/nsm/v1alpha1/nsm_types.go
@@ -46,6 +46,8 @@ const (
 )
 
 type Registry struct {
+	// Number of replicas for the NSM Registry
+	ReplicaCount int32 `json:"replicaCount,omitempty"`
 	// Registry type
 	// +kubebuilder:validation:Enum=k8s;memory
 	Type string `json:"type"`
@@ -82,21 +84,24 @@ type ExclPref struct {
 
 // NSMSpec defines the desired state of NSM
 type NSMSpec struct {
-	// tag represents the desired Network Service Mesh version
-	Version       string            `json:"version"`
-	NsmPullPolicy corev1.PullPolicy `json:"nsmPullPolicy"`
-	// Log level of the NSM components
+	// Tag represents the desired Network Service Mesh version
+	Version string `json:"version"`
+	// Pull policy for NSM images, defaults to IfNotPresent
+	NsmPullPolicy corev1.PullPolicy `json:"nsmPullPolicy,omitempty"`
+	// Log level of the NSM components, defaults to "INFO"
 	NsmLogLevel string `json:"nsmLogLevel,omitempty"`
-	// webhook for nsm
+	// SPIRE agent socket for NSM components, must be set
+	// according to the socket_path parameter of spire-agent
+	SpireAgentSocket string `json:"spireAgentSocket,omitempty"`
+	// Webhook for NSM
 	Webhook Webhook `json:"webhook,omitempty"`
-	// registry for nsm
+	// Registry for NSM
 	Registry Registry `json:"registry"`
-	// NSMGR image string
-	// (must be a complete image path with tag)
+	// Network Service Manager
 	Nsmgr Nsmgr `json:"nsmgr,omitempty"`
-	// exclude-prefixes-k8s
+	// Exclude-prefixes-k8s
 	ExclPref ExclPref `json:"exclPref,omitempty"`
-	// List of forwarders to be used with nsm
+	// List of forwarders to be used with NSM
 	Forwarders []Forwarder `json:"forwarders"`
 }
 

--- a/config/crd/bases/nsm.networkservicemesh.io_nsms.yaml
+++ b/config/crd/bases/nsm.networkservicemesh.io_nsms.yaml
@@ -36,7 +36,7 @@ spec:
             description: NSMSpec defines the desired state of NSM
             properties:
               exclPref:
-                description: exclude-prefixes-k8s
+                description: Exclude-prefixes-k8s
                 properties:
                   envVars:
                     description: EnvVars for ExclPrefImage configuration
@@ -154,7 +154,7 @@ spec:
                     type: string
                 type: object
               forwarders:
-                description: List of forwarders to be used with nsm
+                description: List of forwarders to be used with NSM
                 items:
                   properties:
                     envVars:
@@ -291,15 +291,13 @@ spec:
                   type: object
                 type: array
               nsmLogLevel:
-                description: Log level of the NSM components
+                description: Log level of the NSM components, defaults to "INFO"
                 type: string
               nsmPullPolicy:
-                description: PullPolicy describes a policy for if/when to pull a container
-                  image
+                description: Pull policy for NSM images, defaults to IfNotPresent
                 type: string
               nsmgr:
-                description: NSMGR image string (must be a complete image path with
-                  tag)
+                description: Network Service Manager
                 properties:
                   envVars:
                     description: EnvVars for Nsmgr configuration
@@ -417,7 +415,7 @@ spec:
                     type: string
                 type: object
               registry:
-                description: registry for nsm
+                description: Registry for NSM
                 properties:
                   envVars:
                     description: EnvVars for Registry configuration
@@ -532,6 +530,10 @@ spec:
                   image:
                     description: Registry Image with tag
                     type: string
+                  replicaCount:
+                    description: Number of replicas for the NSM Registry
+                    format: int32
+                    type: integer
                   type:
                     description: Registry type
                     enum:
@@ -541,11 +543,15 @@ spec:
                 required:
                 - type
                 type: object
+              spireAgentSocket:
+                description: SPIRE agent socket for NSM components, must be set according
+                  to the socket_path parameter of spire-agent
+                type: string
               version:
-                description: tag represents the desired Network Service Mesh version
+                description: Tag represents the desired Network Service Mesh version
                 type: string
               webhook:
-                description: webhook for nsm
+                description: Webhook for NSM
                 properties:
                   envVars:
                     description: EnvVars for Webhook configuration
@@ -664,7 +670,6 @@ spec:
                 type: object
             required:
             - forwarders
-            - nsmPullPolicy
             - registry
             - version
             type: object

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: controller
   newName: quay.io/acmenezes/nsm-operator
-  newTag: v1.8.0
+  newTag: v1.9.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -15,7 +15,6 @@ spec:
     metadata:
       labels:
         control-plane: nsm-operator
-        "spiffe.io/spiffe-id": "true"
     spec:
       serviceAccountName: nsm-operator
       containers:

--- a/config/rbac/role_admission-webhook-k8s.yaml
+++ b/config/rbac/role_admission-webhook-k8s.yaml
@@ -1,0 +1,16 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nsm-admission-webhook-k8s-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - "mutatingwebhookconfigurations"
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]

--- a/config/rbac/role_binding-admission-webhook-k8s.yaml
+++ b/config/rbac/role_binding-admission-webhook-k8s.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nsm-admission-webhook-k8s-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: nsm-operator
+    namespace: nsm
+roleRef:
+  kind: ClusterRole
+  name: nsm-admission-webhook-k8s-role
+  apiGroup: rbac.authorization.k8s.io

--- a/config/samples/nsm_v1alpha1_nsm-registry-k8s.yaml
+++ b/config/samples/nsm_v1alpha1_nsm-registry-k8s.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: nsm
 spec:
   version: v1.8.0
-  nsmPullPolicy: IfNotPresent
+#  nsmPullPolicy: IfNotPresent
   nsmLogLevel: TRACE
   
   # Forwarding Plane Configs
@@ -14,6 +14,7 @@ spec:
       image: ghcr.io/networkservicemesh/cmd-forwarder-vpp:v1.8.0
 
   registry:
+    replicaCount: 1
     type: k8s
     image: ghcr.io/networkservicemesh/cmd-registry-k8s:v1.8.0
 

--- a/controllers/nsm/admission-webhook.go
+++ b/controllers/nsm/admission-webhook.go
@@ -59,7 +59,6 @@ func (r *WebhookReconciler) DeploymentForWebhook(nsm *nsmv1alpha1.NSM) *appsv1.D
 	envVars := nsm.Spec.Webhook.EnvVars
 	if envVars == nil {
 		envVars = []corev1.EnvVar{
-			{Name: "SPIFFE_ENDPOINT_SOCKET", Value: "unix:///run/spire/sockets/agent.sock"},
 			{Name: "NSM_SERVICE_NAME", Value: "admission-webhook-svc"},
 			{Name: "NSM_NAME", ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
@@ -93,7 +92,7 @@ func (r *WebhookReconciler) DeploymentForWebhook(nsm *nsmv1alpha1.NSM) *appsv1.D
 						Name:            "admission-webhook-k8s",
 						Image:           nsm.Spec.Webhook.Image,
 						ImagePullPolicy: nsm.Spec.NsmPullPolicy,
-						Env:             envVars,
+						Env:             insertSpireAgentSocketEnv(envVars, getSpireAgentSocket(nsm)),
 						ReadinessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/controllers/nsm/controller.go
+++ b/controllers/nsm/controller.go
@@ -158,3 +158,27 @@ func getNsmLogLevel(nsm *nsmv1alpha1.NSM) string {
 	}
 	return "INFO"
 }
+
+func getSpireAgentSocket(nsm *nsmv1alpha1.NSM) string {
+	SpireAgentSocket := nsm.Spec.SpireAgentSocket
+	if SpireAgentSocket == "" {
+		SpireAgentSocket = "unix:///run/spire/sockets/agent.sock"
+	}
+	return SpireAgentSocket
+}
+
+// If SpireAgentSocket is defined in the CR then its value will be used in
+// SPIFFE_ENDPOINT_SOCKET environment variable
+func insertSpireAgentSocketEnv(envVars []corev1.EnvVar, SpireAgentSocket string) []corev1.EnvVar {
+	SpireAgentSocketEnv := []corev1.EnvVar{{Name: "SPIFFE_ENDPOINT_SOCKET", Value: SpireAgentSocket}}
+	for idx, envVar := range envVars {
+		if envVar.Name == "SPIFFE_ENDPOINT_SOCKET" {
+			envVars = removeItem(envVars, idx)
+		}
+	}
+	return append(SpireAgentSocketEnv, envVars...)
+}
+
+func removeItem(EnvVars []corev1.EnvVar, index int) []corev1.EnvVar {
+	return append(EnvVars[:index], EnvVars[index+1:]...)
+}

--- a/controllers/nsm/forwarder.go
+++ b/controllers/nsm/forwarder.go
@@ -68,9 +68,8 @@ func (r *ForwarderReconciler) daemonSetForForwarder(nsm *nsmv1alpha1.NSM, object
 	privmode := true
 	forwarderLabel := map[string]string{"app": "forwarder", "spiffe.io/spiffe-id": "true"}
 
-	EnvVars := envVars
-	if EnvVars == nil {
-		EnvVars = getEnvVars(nsm, ForwarderType)
+	if envVars == nil {
+		envVars = getEnvVars(nsm, ForwarderType)
 	}
 
 	daemonset := &appsv1.DaemonSet{
@@ -99,7 +98,7 @@ func (r *ForwarderReconciler) daemonSetForForwarder(nsm *nsmv1alpha1.NSM, object
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &privmode,
 							},
-							Env:            EnvVars,
+							Env:            insertSpireAgentSocketEnv(envVars, getSpireAgentSocket(nsm)),
 							ReadinessProbe: getReadinessProbe(ForwarderType),
 							LivenessProbe:  getLivenessProbe(ForwarderType),
 							StartupProbe:   getStartupProbe(ForwarderType),
@@ -164,7 +163,6 @@ func getForwarderResourceReqs(ForwarderType nsmv1alpha1.ForwarderType) corev1.Re
 func getEnvVars(nsm *nsmv1alpha1.NSM, ForwarderType nsmv1alpha1.ForwarderType) []corev1.EnvVar {
 
 	EnvVars := []corev1.EnvVar{
-		{Name: "SPIFFE_ENDPOINT_SOCKET", Value: "unix:///run/spire/sockets/agent.sock"},
 		{Name: "NSM_TUNNEL_IP", ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{
 				FieldPath: "status.podIP",

--- a/hack/nsm-operator-ci.yaml
+++ b/hack/nsm-operator-ci.yaml
@@ -98,7 +98,7 @@ spec:
             description: NSMSpec defines the desired state of NSM
             properties:
               exclPref:
-                description: exclude-prefixes-k8s
+                description: Exclude-prefixes-k8s
                 properties:
                   envVars:
                     description: EnvVars for ExclPrefImage configuration
@@ -216,7 +216,7 @@ spec:
                     type: string
                 type: object
               forwarders:
-                description: List of forwarders to be used with nsm
+                description: List of forwarders to be used with NSM
                 items:
                   properties:
                     envVars:
@@ -353,15 +353,13 @@ spec:
                   type: object
                 type: array
               nsmLogLevel:
-                description: Log level of the NSM components
+                description: Log level of the NSM components, defaults to "INFO"
                 type: string
               nsmPullPolicy:
-                description: PullPolicy describes a policy for if/when to pull a container
-                  image
+                description: Pull policy for NSM images, defaults to IfNotPresent
                 type: string
               nsmgr:
-                description: NSMGR image string (must be a complete image path with
-                  tag)
+                description: Network Service Manager
                 properties:
                   envVars:
                     description: EnvVars for Nsmgr configuration
@@ -479,7 +477,7 @@ spec:
                     type: string
                 type: object
               registry:
-                description: registry for nsm
+                description: Registry for NSM
                 properties:
                   envVars:
                     description: EnvVars for Registry configuration
@@ -594,6 +592,10 @@ spec:
                   image:
                     description: Registry Image with tag
                     type: string
+                  replicaCount:
+                    description: Number of replicas for the NSM Registry
+                    format: int32
+                    type: integer
                   type:
                     description: Registry type
                     enum:
@@ -603,11 +605,15 @@ spec:
                 required:
                 - type
                 type: object
+              spireAgentSocket:
+                description: SPIRE agent socket for NSM components, must be set according
+                  to the socket_path parameter of spire-agent
+                type: string
               version:
-                description: tag represents the desired Network Service Mesh version
+                description: Tag represents the desired Network Service Mesh version
                 type: string
               webhook:
-                description: webhook for nsm
+                description: Webhook for NSM
                 properties:
                   envVars:
                     description: EnvVars for Webhook configuration
@@ -726,7 +732,6 @@ spec:
                 type: object
             required:
             - forwarders
-            - nsmPullPolicy
             - registry
             - version
             type: object
@@ -934,7 +939,23 @@ rules:
       - "networkservices"
       - "networkserviceendpoints"
     verbs: ["*"]
-
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nsm-admission-webhook-k8s-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - "mutatingwebhookconfigurations"
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -975,6 +996,19 @@ roleRef:
   name: nsm-registry-k8s-role
   apiGroup: rbac.authorization.k8s.io
 ---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nsm-admission-webhook-k8s-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: nsm-operator
+    namespace: nsm
+roleRef:
+  kind: ClusterRole
+  name: nsm-admission-webhook-k8s-role
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -1004,14 +1038,13 @@ spec:
     metadata:
       labels:
         control-plane: nsm-operator
-        spiffe.io/spiffe-id: "true"
     spec:
       containers:
       - args:
         - --enable-leader-election
         command:
         - /manager
-        image: quay.io/acmenezes/nsm-operator:v1.8.0
+        image: quay.io/acmenezes/nsm-operator:v1.9.0
         name: manager
         resources:
           limits:


### PR DESCRIPTION
Makefile:
-  The ci-yaml generation fixed, a missing separator inserted, roles and binding for admission-webhook-k8s added.

CRD:
- Replica count parameter is added to Registry
- spireAgentSocket is added to NSM level parameters
- nsmPullPolicy is not required because we use default

Handling of environment variables fixed and extended:
- Every components can handle environment variables coming from CR
- If spireAgentSocket is defined in the CR then it will be used from there even if SPIFFE_ENDPOINT_SOCKET is given as environment variable or default is used.

Registry:
- The reconciler can update the registry deployment in case the replica count changed in the CR.